### PR TITLE
Adjusted the library name of the badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RIR Statistics Exchange Format in Rust (rsef-rs)
-[![Build Status](https://github.com/DevQps/mrt-rs/workflows/CI/badge.svg)](https://github.com/DevQps/mrt-rs)
-[![codecov](https://codecov.io/gh/DevQps/mrt-rs/branch/master/graph/badge.svg)](https://codecov.io/gh/DevQps/mrt-rs)
-[![Crates](https://img.shields.io/crates/v/mrt_rs.svg)](https://crates.io/crates/mrt-rs)
+[![Build Status](https://github.com/DevQps/rsef-rs/workflows/CI/badge.svg)](https://github.com/DevQps/mrt-rs)
+[![codecov](https://codecov.io/gh/DevQps/rsef-rs/branch/master/graph/badge.svg)](https://codecov.io/gh/DevQps/mrt-rs)
+[![Crates](https://img.shields.io/crates/v/rsef_rs.svg)](https://crates.io/crates/mrt-rs)
 
 A library for downloading and parsing RIR Statistics Exchange Format (RSEF) listings in Rust.
 


### PR DESCRIPTION
# Description
Due to a copy-paste error the badge names still need to be changed to rsef-rs instead of mrt-rs.